### PR TITLE
Fix and test examples

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,41 +1,12 @@
-name: CI
+name: Documentation
+
 on:
   push:
     branches: ["main"]
   pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
-  test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
-      actions: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - '1.11'
-          - 'lts'
-          - 'pre'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-
-      - uses: julia-actions/julia-runtest@v1
-
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -2,7 +2,7 @@ name: pre-commit
 
 on:
   push:
-    branches: ["*"]
+    branches: ["main"]
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,80 @@
+name: Testing
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  run-tests:
+    name: Run tests (Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
+      actions: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.11'
+          - 'lts'
+          - 'pre'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+
+      - uses: julia-actions/julia-runtest@v1
+
+
+  run-examples:
+    name: Run examples (Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
+      actions: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.11'
+          - 'lts'
+          - 'pre'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+
+      - name: Instantiate examples environment
+        working-directory: examples/
+        run: julia --project=. -e 'import Pkg; Pkg.develop(path=".."); Pkg.instantiate()'
+
+      - name: Run all examples
+        working-directory: examples/
+        run: |
+          for f in *.jl; do
+            julia --project=. "$f"
+          done

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,9 +1,9 @@
 [deps]
+CGcoefficient = "c862aa61-d51e-47d1-b396-b1e789b4e0b6"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MQDT = "1bfeae05-7215-4237-8fdd-b424babe7f02"
 Parquet2 = "98572fba-bba0-415d-956f-fa77e587d26d"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"


### PR DESCRIPTION
Since we use PythonCall.jl this is not compatible with Pyplot.jl, which uses PyCall.jl.
However, in principle, there is a replacement [PythonPlot.jl](https://github.com/JuliaPy/PythonPlot.jl), which is a replacement of PyPlot.jl but instead also using PythonCall.jl
For some reason, when using PythonPlot, resolving the python dependencies leads to some error (it says ryd-numerov cannot resolve numba and numpy depencies, which is strange because without PythonPlot it works ...)

For now we can also simply remove PyPlot entirely, since I think it was anyway just used as backend for Plots.jl