### PR TITLE
calculate all radial_matrix elements

### DIFF
--- a/src/matrixelements.jl
+++ b/src/matrixelements.jl
@@ -73,9 +73,7 @@ function radial_matrix(s1::BasisState, s2::BasisState, order::Int)
             lj = s2.lr[j]
 
             if abs(li-lj) <= order
-                if max(nui, nuj) < 25 || abs(nui-nuj) < 11 # cut off calculation of matrix elements for F states and higher \ell
-                    R[i, j] = radial_moment_cached(s1.species, nui, li, nuj, lj, order)
-                end
+                R[i, j] = radial_moment_cached(s1.species, nui, li, nuj, lj, order)
             end
         end
     end


### PR DESCRIPTION
The condition
```
if max(nui, nuj) < 25 || abs(nui-nuj) < 11
```
should be 
```
if min(nui, nuj) < 25 || abs(nui-nuj) < 11
```

However, I think it is even more convenient to actually here always calculate all elements, and put this condition inside the database generation, see for this https://github.com/pairinteraction/database-mqdt/pull/4 and specifically https://github.com/pairinteraction/database-mqdt/pull/4/commits/df5e2ddb0b447b34ee943c7ee614e403c33532a4